### PR TITLE
build: align `nextrap-base` version strategy with other packages

### DIFF
--- a/nextrap-base/nt-framework/project.json
+++ b/nextrap-base/nt-framework/project.json
@@ -1,22 +1,21 @@
 {
-  "name": "nt-framework",
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "nextrap-base/nt-framework/src",
-  "projectType": "library",
-  "release": {
-    "version": {
-      "currentVersionResolver": "git-tag",
-      "fallbackCurrentVersionResolver": "disk",
-      "preserveLocalDependencyProtocols": false,
-      "manifestRootsToUpdate": ["dist/{projectRoot}"]
+    "name": "nt-framework",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "nextrap-base/nt-framework/src",
+    "projectType": "library",
+    "release": {
+        "version": {
+            "currentVersionResolver": "disk",
+            "preserveLocalDependencyProtocols": false,
+            "manifestRootsToUpdate": ["{projectRoot}"]
+        }
+    },
+    "tags": [],
+    "targets": {
+        "nx-release-publish": {
+            "options": {
+                "packageRoot": "dist/{projectRoot}"
+            }
+        }
     }
-  },
-  "tags": [],
-  "targets": {
-    "nx-release-publish": {
-      "options": {
-        "packageRoot": "dist/{projectRoot}"
-      }
-    }
-  }
 }

--- a/nextrap-base/style-base/project.json
+++ b/nextrap-base/style-base/project.json
@@ -1,22 +1,21 @@
 {
-  "name": "style-base",
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "nextrap-base/style-base/src",
-  "projectType": "library",
-  "release": {
-    "version": {
-      "currentVersionResolver": "git-tag",
-      "fallbackCurrentVersionResolver": "disk",
-      "preserveLocalDependencyProtocols": false,
-      "manifestRootsToUpdate": ["dist/{projectRoot}"]
+    "name": "style-base",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "nextrap-base/style-base/src",
+    "projectType": "library",
+    "release": {
+        "version": {
+            "currentVersionResolver": "disk",
+            "preserveLocalDependencyProtocols": false,
+            "manifestRootsToUpdate": ["{projectRoot}"]
+        }
+    },
+    "tags": [],
+    "targets": {
+        "nx-release-publish": {
+            "options": {
+                "packageRoot": "dist/{projectRoot}"
+            }
+        }
     }
-  },
-  "tags": [],
-  "targets": {
-    "nx-release-publish": {
-      "options": {
-        "packageRoot": "dist/{projectRoot}"
-      }
-    }
-  }
 }

--- a/nextrap-base/style-button/project.json
+++ b/nextrap-base/style-button/project.json
@@ -1,21 +1,21 @@
 {
-  "name": "style-button",
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "nextrap-base/style-button/src",
-  "projectType": "library",
-  "release": {
-    "version": {
-      "manifestRootsToUpdate": ["dist/{projectRoot}"],
-      "currentVersionResolver": "git-tag",
-      "fallbackCurrentVersionResolver": "disk"
+    "name": "style-button",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "nextrap-base/style-button/src",
+    "projectType": "library",
+    "release": {
+        "version": {
+            "currentVersionResolver": "disk",
+            "preserveLocalDependencyProtocols": false,
+            "manifestRootsToUpdate": ["{projectRoot}"]
+        }
+    },
+    "tags": [],
+    "targets": {
+        "nx-release-publish": {
+            "options": {
+                "packageRoot": "dist/{projectRoot}"
+            }
+        }
     }
-  },
-  "tags": [],
-  "targets": {
-    "nx-release-publish": {
-      "options": {
-        "packageRoot": "dist/{projectRoot}"
-      }
-    }
-  }
 }

--- a/nextrap-base/style-reset/project.json
+++ b/nextrap-base/style-reset/project.json
@@ -1,22 +1,21 @@
 {
-  "name": "style-reset",
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "nextrap-base/style-reset/src",
-  "projectType": "library",
-  "release": {
-    "version": {
-      "currentVersionResolver": "git-tag",
-      "fallbackCurrentVersionResolver": "disk",
-      "preserveLocalDependencyProtocols": false,
-      "manifestRootsToUpdate": ["dist/{projectRoot}"]
+    "name": "style-reset",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "nextrap-base/style-reset/src",
+    "projectType": "library",
+    "release": {
+        "version": {
+            "currentVersionResolver": "disk",
+            "preserveLocalDependencyProtocols": false,
+            "manifestRootsToUpdate": ["{projectRoot}"]
+        }
+    },
+    "tags": [],
+    "targets": {
+        "nx-release-publish": {
+            "options": {
+                "packageRoot": "dist/{projectRoot}"
+            }
+        }
     }
-  },
-  "tags": [],
-  "targets": {
-    "nx-release-publish": {
-      "options": {
-        "packageRoot": "dist/{projectRoot}"
-      }
-    }
-  }
 }


### PR DESCRIPTION
Hi @dermatthes,

zu deinen Mails gestern.

Ich weiß nicht genau, welches Paket in deiner zweiten Mail von 11:46 gemeint war, aber es gibt grundsätzlich mehrere Strategien, an welcher Stelle nx die aktuelle Version feststellt und/oder updated (package.json, git-tag, npm registry) (siehe z.B. [hier](https://nx.dev/recipes/nx-release/updating-version-references)).

Die Einstellungen zur Versionierung in den base-Paketen war unterschiedlich im Vergleich zu allen anderen. Ich nehme an, daher kam der Fehler beim Build und die fehlende Aktualisierung der Versionsnummer.

Normalerweise sollte mit diesen Anpassungen (bzw. denselben Einstellungen in jedem Paket) die Versionierung dann korrekt laufen, wenn man wie in der [README](https://github.com/nextrap/nextrap-monorepo#releases) beschrieben vorgeht.

Wir können gerne nochmal drüber sprechen, wie du gestern vorgegangen bist und welche Strategie wir nutzen wollen. Hab dich vorhin noch nicht erreicht, du kannst mich gerne später nochmal anrufen, wenn es dir passt.

Gruß
Enzo