### PR TITLE
fix: do not re-export lit via nt-framework

### DIFF
--- a/nextrap-base/nt-framework/package.json
+++ b/nextrap-base/nt-framework/package.json
@@ -2,9 +2,7 @@
     "name": "@nextrap/nt-framework",
     "version": "1.1.1",
     "main": "./index.js",
-    "dependencies": {
-        "lit": "^3.2.0"
-    },
+    "dependencies": {},
     "type": "module",
     "types": "./index.d.ts"
 }

--- a/nextrap-base/nt-framework/src/index.ts
+++ b/nextrap-base/nt-framework/src/index.ts
@@ -3,8 +3,6 @@ export * from './util/Debouncer';
 export * from './util/SlotTool';
 export * from './util/wait-for';
 
-export * from 'lit';
-export * from 'lit/decorators.js';
 export * from './lib/decorators';
 export * from './lib/global-events';
 export * from './lib/nt-simple-element';

--- a/nextrap-elements/nte-burger/src/lib/nte-burger.ts
+++ b/nextrap-elements/nte-burger/src/lib/nte-burger.ts
@@ -1,12 +1,6 @@
-import {
-  customElement,
-  EVENT_NAME_GROUP_OPEN_CLOSE,
-  eventListener,
-  property,
-  triggerGroupOpenCloseEvent,
-  unsafeCSS,
-} from '@nextrap/nt-framework';
-import { LitElement } from 'lit';
+import { EVENT_NAME_GROUP_OPEN_CLOSE, eventListener, triggerGroupOpenCloseEvent } from '@nextrap/nt-framework';
+import { LitElement, unsafeCSS } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import style from './hamburger.scss?inline';
 
 import { html } from 'lit/static-html.js';

--- a/nextrap-elements/nte-nav/src/lib/nte-nav.ts
+++ b/nextrap-elements/nte-nav/src/lib/nte-nav.ts
@@ -1,9 +1,9 @@
 import { ka_dom_ready } from '@kasimirjs/core';
-import { customElement, isBiggerThanBreakpoint, property, unsafeCSS } from '@nextrap/nt-framework';
+import { isBiggerThanBreakpoint } from '@nextrap/nt-framework';
 import '@nextrap/nte-offcanvas';
 import { NteOffcanvas } from '@nextrap/nte-offcanvas';
-import { html, LitElement, PropertyValues } from 'lit';
-import { state } from 'lit/decorators.js';
+import { html, LitElement, PropertyValues, unsafeCSS } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 import style from './nav.scss?inline';
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,10 +55,7 @@
         },
         "nextrap-base/nt-framework": {
             "name": "@nextrap/nt-framework",
-            "version": "1.1.1",
-            "dependencies": {
-                "lit": "^3.2.0"
-            }
+            "version": "1.1.1"
         },
         "nextrap-base/nt-scope": {
             "name": "@nextrap/nt-scope",


### PR DESCRIPTION
@dermatthes Ich habe mir dein Problem it nte-nav/NtElementDefinition angeschaut, aber konnte das nicht nachstellen - ich hatte keine fehlerhaften/relativen Import-Pfade in keinem der Builds.

Mir ist aber aufgefallen, dass du das lit-Framework nochmal via nt-framework exportierst bzw. in den anderen Packages importierst und dass wir in nt-framework eine separate Angabe der lit-Dependency haben. Das habe ich aufgelöst.

Ich denke, so ist es klarer und einfacher zu verstehen, wo letztlich ein Import herkommt.

Probier mal, ob der Fehler bei dir noch auftritt nach

- `npm i`
- `nx reset`
- `nx run-many -t build`