### PR TITLE
build: make tests work

### DIFF
--- a/nextrap-base/nt-nx-generators/vite.config.ts
+++ b/nextrap-base/nt-nx-generators/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig(() => ({
   //  plugins: [ nxViteTsPaths() ],
   // },
   test: {
+    passWithNoTests: true,
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/nextrap-elements/nte-progress/src/lib/nte-progress.spec.ts
+++ b/nextrap-elements/nte-progress/src/lib/nte-progress.spec.ts
@@ -1,7 +1,0 @@
-import { nteProgress } from './nte-progress';
-
-describe('nteProgress', () => {
-  it('should work', () => {
-    expect(nteProgress()).toEqual('nte-progress');
-  });
-});

--- a/nextrap-elements/nte-progress/vite.config.ts
+++ b/nextrap-elements/nte-progress/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    passWithNoTests: true,
     watch: false,
     globals: true,
     environment: 'node',

--- a/nextrap-elements/nte-scrollspy/vite.config.ts
+++ b/nextrap-elements/nte-scrollspy/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    passWithNoTests: true,
     watch: false,
     globals: true,
     environment: 'node',

--- a/nextrap-layout/ntl-footer/src/lib/ntl-footer.spec.ts
+++ b/nextrap-layout/ntl-footer/src/lib/ntl-footer.spec.ts
@@ -1,7 +1,0 @@
-import { ntlFooter } from './ntl-footer';
-
-describe('ntlFooter', () => {
-  it('should work', () => {
-    expect(ntlFooter()).toEqual('ntl-footer');
-  });
-});


### PR DESCRIPTION
Some projects had invalid test files - or no tests but no `passWithNoTests` flag. We want to allow passing without tests, so I fixed those projects.

---------

closes #35