### PR TITLE
68 nte theme switcher

### DIFF
--- a/nextrap-elements/nte-demo-viewer/demo/base.html
+++ b/nextrap-elements/nte-demo-viewer/demo/base.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <body>
+    <nte-theme-switcher themes="light, dark"></nte-theme-switcher>
+
     <nte-demo-viewer welcome-title="nte-demo-viewer" readme="/README.md">
       <demo
         title="Basic Usage"

--- a/nextrap-elements/nte-demo-viewer/demo/main.ts
+++ b/nextrap-elements/nte-demo-viewer/demo/main.ts
@@ -1,2 +1,3 @@
+import '@nextrap/nte-theme-switcher';
 import '@nextrap/style-base';
 import '../index.ts';

--- a/nextrap-elements/nte-demo-viewer/demo/main.ts
+++ b/nextrap-elements/nte-demo-viewer/demo/main.ts
@@ -1,3 +1,2 @@
-import '@nextrap/nte-theme-switcher';
 import '@nextrap/style-base';
 import '../index.ts';

--- a/nextrap-elements/nte-demo-viewer/index.ts
+++ b/nextrap-elements/nte-demo-viewer/index.ts
@@ -1,4 +1,4 @@
 export * from './src/components/nte-demo-viewer/nte-demo-viewer';
 
 /* this bundles light dom styles by default */
-export * from './src/styles/index.scss';
+import './src/styles/index.scss';

--- a/nextrap-elements/nte-demo-viewer/index.ts
+++ b/nextrap-elements/nte-demo-viewer/index.ts
@@ -1,4 +1,5 @@
 export * from './src/components/nte-demo-viewer/nte-demo-viewer';
+export * from './src/components/nte-theme-switcher/nte-theme-switcher';
 
 /* this bundles light dom styles by default */
 import './src/styles/index.scss';

--- a/nextrap-elements/nte-demo-viewer/src/components/nte-theme-switcher/nte-theme-switcher.scss
+++ b/nextrap-elements/nte-demo-viewer/src/components/nte-theme-switcher/nte-theme-switcher.scss
@@ -1,0 +1,56 @@
+/* The ShadowDOM Styles - defined inline in the component via css`` tag */
+:host {
+  display: block;
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 9999;
+}
+
+.switcher {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 0.375rem 0.625rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 0.8125rem;
+}
+
+.label {
+  color: #666;
+  user-select: none;
+  white-space: nowrap;
+}
+
+select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: #f5f5f5
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23666'/%3E%3C/svg%3E")
+    no-repeat right 0.5rem center;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 0.25rem 1.5rem 0.25rem 0.5rem;
+  font-size: 0.8125rem;
+  font-family: inherit;
+  color: #333;
+  cursor: pointer;
+  min-width: 100px;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+select:hover {
+  border-color: #bbb;
+}
+
+select:focus {
+  border-color: #888;
+}

--- a/nextrap-elements/nte-demo-viewer/src/components/nte-theme-switcher/nte-theme-switcher.ts
+++ b/nextrap-elements/nte-demo-viewer/src/components/nte-theme-switcher/nte-theme-switcher.ts
@@ -1,0 +1,129 @@
+import { resetStyle } from '@nextrap/style-reset';
+import { html, LitElement, nothing, unsafeCSS } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import style from './nte-theme-switcher.scss?inline';
+/**
+ * Theme Switcher component that sets a theme class on the body element
+ * and syncs the selected theme with URL parameters.
+ *
+ * @element nte-theme-switcher
+ *
+ * @property {string} themes - Comma-separated list of available theme names
+ */
+@customElement('nte-theme-switcher')
+export class NteThemeSwitcherElement extends LitElement {
+  static override styles = [unsafeCSS(style), unsafeCSS(resetStyle)];
+
+  /**
+   * Comma-separated list of available theme names
+   */
+  @property({ type: String })
+  accessor themes = '';
+
+  /**
+   * Currently active theme
+   */
+  @state()
+  private accessor _activeTheme = 'default';
+
+  /**
+   * Parsed list of available themes
+   */
+  @state()
+  private accessor _themeList: string[] = [];
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this._parseThemes();
+    this._readThemeFromUrl();
+    this._applyTheme();
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this._removeThemeClass();
+  }
+
+  /**
+   * Parse the themes property into an array
+   */
+  private _parseThemes() {
+    if (!this.themes) {
+      this._themeList = [];
+      return;
+    }
+    this._themeList = this.themes
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+  }
+
+  /**
+   * Read theme from URL parameter `?theme=XYZ`
+   */
+  private _readThemeFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    const urlTheme = params.get('theme');
+    if (urlTheme && (this._themeList.includes(urlTheme) || urlTheme === 'default')) {
+      this._activeTheme = urlTheme;
+    }
+  }
+
+  /**
+   * Update URL parameter without page reload
+   */
+  private _updateUrl() {
+    const url = new URL(window.location.href);
+    if (this._activeTheme === 'default') {
+      url.searchParams.delete('theme');
+    } else {
+      url.searchParams.set('theme', this._activeTheme);
+    }
+    window.history.replaceState(null, '', url.toString());
+  }
+
+  /**
+   * Apply the theme class to the body element
+   */
+  private _applyTheme() {
+    this._removeThemeClass();
+
+    if (this._activeTheme !== 'default') {
+      document.body.classList.add(`theme-${this._activeTheme}`);
+    }
+  }
+
+  /**
+   * Remove all theme classes from the body element (cleanup)
+   */
+  private _removeThemeClass() {
+    const allThemeClasses = this._themeList.map((t) => `theme-${t}`);
+    document.body.classList.remove(...allThemeClasses);
+  }
+
+  /**
+   * Handle theme selection change
+   */
+  private _onThemeChange(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    this._activeTheme = select.value;
+    this._applyTheme();
+    this._updateUrl();
+  }
+
+  override render() {
+    if (this._themeList.length === 0) return nothing;
+
+    return html`
+      <div class="switcher">
+        <span class="label">Theme:</span>
+        <select @change="${this._onThemeChange}" .value="${this._activeTheme}">
+          <option value="default">Default / System</option>
+          ${this._themeList.map(
+            (theme) => html` <option value="${theme}" ?selected="${theme === this._activeTheme}">${theme}</option> `,
+          )}
+        </select>
+      </div>
+    `;
+  }
+}

--- a/nextrap-elements/nte-demo-viewer/src/styles/index.scss
+++ b/nextrap-elements/nte-demo-viewer/src/styles/index.scss
@@ -1,3 +1,86 @@
 /**
  * Light DOM Styles for Demo Viewer
+ * 
+ * These styles restore margins/paddings for markdown content
+ * that may be reset by global CSS resets.
  */
+
+// Restore typography spacing for markdown content
+nte-demo-viewer {
+  [slot='demo-content'],
+  [slot='readme-content'] {
+    // Headings
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin-top: 1.5em;
+      margin-bottom: 0.5em;
+
+      &:first-child {
+        margin-top: 0;
+      }
+    }
+
+    // Paragraphs
+    p {
+      margin-top: 0;
+      margin-bottom: 1em;
+    }
+
+    // Lists
+    ul,
+    ol {
+      margin-top: 0;
+      margin-bottom: 1em;
+      padding-left: 2em;
+    }
+
+    ul {
+      list-style: disc;
+    }
+
+    ol {
+      list-style: decimal;
+    }
+
+    li {
+      margin-bottom: 0.25em;
+    }
+
+    // Blockquotes
+    blockquote {
+      margin: 1em 0;
+      padding-left: 1em;
+      border-left: 4px solid #e0e0e0;
+    }
+
+    // Code blocks
+    pre {
+      margin: 1em 0;
+      padding: 1em;
+    }
+
+    // Inline code
+    code {
+      padding: 0.2em 0.4em;
+    }
+
+    // Tables
+    table {
+      margin: 1em 0;
+    }
+
+    th,
+    td {
+      padding: 0.5em 0.75em;
+    }
+
+    // Horizontal rules
+    hr {
+      margin: 1.5em 0;
+    }
+  }
+}

--- a/nextrap-elements/nte-theme-switcher/README.md
+++ b/nextrap-elements/nte-theme-switcher/README.md
@@ -1,19 +1,45 @@
 # nte-theme-switcher
 
-Short description of the component.
+A lightweight Lit Web Component for switching themes via CSS classes on the `<body>` element.
 
-## Example
+## Installation
 
-| Attribute | Type   | Description          | Default |
-| --------- | ------ | -------------------- | ------- |
-| attr1     | string | Description of attr1 | 'value' |
+```bash
+npm install @nextrap/nte-theme-switcher
+```
 
-### Attr1
+## Usage
 
-Description of attr1.
+```html
+<nte-theme-switcher themes="light, dark, high-contrast"></nte-theme-switcher>
+```
 
-### Attr2
+The component adds a `theme-{name}` class to the `<body>` element when a theme is selected.
 
-Description of attr2.
+## Properties
 
-## Example Usage
+| Property | Type   | Default | Description                                                    |
+| -------- | ------ | ------- | -------------------------------------------------------------- |
+| themes   | string | `""`    | Comma-separated list of theme names (prefixed with `theme-`)  |
+
+## Styling
+
+Use the theme classes in your CSS:
+
+```css
+/* Default styles */
+.my-element { background: white; color: black; }
+
+/* Dark theme */
+.theme-dark .my-element { background: #1a1a1a; color: white; }
+
+/* High contrast theme */
+.theme-high-contrast .my-element { background: black; color: yellow; }
+```
+
+## Features
+
+- **CSS Class Based** — Sets `theme-{name}` class on `<body>` for easy CSS styling
+- **URL Sync** — Theme persists via `?theme=...` URL parameter
+- **Default Option** — "Default / System" removes the class and cleans the URL
+- **Shadow DOM** — Component styles are encapsulated

--- a/nextrap-elements/nte-theme-switcher/index.html
+++ b/nextrap-elements/nte-theme-switcher/index.html
@@ -74,22 +74,22 @@
   <body>
     <h1>nte-theme-switcher</h1>
     <p>
-      A lightweight Web Component for switching themes via <code>data-theme</code> attribute.
+      A lightweight Web Component for switching themes via CSS classes on the <code>&lt;body&gt;</code> element.
       <span class="badge">Lit</span>
     </p>
 
     <h2>Live Demo</h2>
     <p>
-      The theme switcher is active in the bottom-left corner of this page. Select a theme to see the
-      <code>data-theme</code> attribute change on <code>&lt;html&gt;</code>.
+      The theme switcher is active below. Select a theme to see the CSS class change on <code>&lt;body&gt;</code> (e.g.
+      <code>class="theme-dark"</code>).
     </p>
 
-    <nte-theme-switcher themes="light, dark, high-contrast" target="html"></nte-theme-switcher>
+    <nte-theme-switcher themes="light, dark, high-contrast"></nte-theme-switcher>
 
     <div class="theme-preview">
       <p>
-        <strong>Current <code>data-theme</code>:</strong> Check <code>&lt;html&gt;</code> element in DevTools to see the
-        applied attribute.
+        <strong>Current theme class:</strong> Check <code>&lt;body&gt;</code> element in DevTools to see the applied
+        class (e.g. <code>theme-light</code>, <code>theme-dark</code>).
       </p>
     </div>
 
@@ -97,7 +97,6 @@
     <pre>
 &lt;nte-theme-switcher
   themes="light, dark, high-contrast"
-  target="html"
 &gt;&lt;/nte-theme-switcher&gt;</pre
     >
 
@@ -116,56 +115,34 @@
           <td><code>themes</code></td>
           <td><code>string</code></td>
           <td><code>""</code></td>
-          <td>Comma-separated list of theme names</td>
-        </tr>
-        <tr>
-          <td><code>target</code></td>
-          <td><code>string</code></td>
-          <td><code>"html"</code></td>
-          <td>Target element: <code>"html"</code>, <code>"body"</code>, <code>"current"</code>, or an element ID</td>
+          <td>Comma-separated list of theme names (classes will be prefixed with <code>theme-</code>)</td>
         </tr>
       </tbody>
     </table>
 
     <h2>Features</h2>
     <ul>
-      <li><strong>URL Sync</strong> &mdash; Theme persists via <code>?theme=...</code> URL parameter</li>
       <li>
-        <strong>Flexible Target</strong> &mdash; Set <code>data-theme</code> on <code>html</code>, <code>body</code>,
-        the component itself, or any element by ID
+        <strong>CSS Class Based</strong> &mdash; Sets <code>theme-{name}</code> class on <code>&lt;body&gt;</code>
       </li>
-      <li><strong>Default Option</strong> &mdash; "Default / System" removes the attribute and cleans the URL</li>
+      <li><strong>URL Sync</strong> &mdash; Theme persists via <code>?theme=...</code> URL parameter</li>
+      <li><strong>Default Option</strong> &mdash; "Default / System" removes the class and cleans the URL</li>
       <li><strong>No Dependencies</strong> &mdash; Only requires Lit</li>
       <li><strong>Shadow DOM</strong> &mdash; Styles are encapsulated</li>
     </ul>
 
-    <h2>Target Options</h2>
-    <table>
-      <thead>
-        <tr>
-          <th>Value</th>
-          <th>Behavior</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>"html"</code></td>
-          <td>Sets <code>data-theme</code> on <code>document.documentElement</code></td>
-        </tr>
-        <tr>
-          <td><code>"body"</code></td>
-          <td>Sets <code>data-theme</code> on <code>document.body</code></td>
-        </tr>
-        <tr>
-          <td><code>"current"</code></td>
-          <td>Sets <code>data-theme</code> on the <code>&lt;nte-theme-switcher&gt;</code> element itself</td>
-        </tr>
-        <tr>
-          <td>Any other string</td>
-          <td>Interpreted as element ID via <code>document.getElementById()</code></td>
-        </tr>
-      </tbody>
-    </table>
+    <h2>Styling with Theme Classes</h2>
+    <p>Use the theme classes in your CSS to style elements based on the selected theme:</p>
+    <pre>
+/* Default styles */
+.my-element { background: white; color: black; }
+
+/* Dark theme */
+.theme-dark .my-element { background: #1a1a1a; color: white; }
+
+/* Light theme */
+.theme-light .my-element { background: #fafafa; color: #333; }</pre
+    >
 
     <script src="/demo/main.js" type="module"></script>
   </body>

--- a/nextrap-elements/nte-theme-switcher/src/components/nte-theme-switcher/nte-theme-switcher.ts
+++ b/nextrap-elements/nte-theme-switcher/src/components/nte-theme-switcher/nte-theme-switcher.ts
@@ -3,14 +3,12 @@ import { html, LitElement, nothing, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import style from './nte-theme-switcher.scss?inline';
 /**
- * Theme Switcher component that sets a `data-theme` attribute on a target element
+ * Theme Switcher component that sets a theme class on the body element
  * and syncs the selected theme with URL parameters.
  *
  * @element nte-theme-switcher
  *
  * @property {string} themes - Comma-separated list of available theme names
- * @property {string} target - Target element for `data-theme` attribute:
- *   "html" (default), "body", "current" (self), or an element ID
  */
 @customElement('nte-theme-switcher')
 export class NteThemeSwitcherElement extends LitElement {
@@ -21,13 +19,6 @@ export class NteThemeSwitcherElement extends LitElement {
    */
   @property({ type: String })
   public themes = '';
-
-  /**
-   * Target element for the data-theme attribute.
-   * "html" | "body" | "current" | element ID
-   */
-  @property({ type: String })
-  public target = 'html';
 
   /**
    * Currently active theme
@@ -50,7 +41,7 @@ export class NteThemeSwitcherElement extends LitElement {
 
   override disconnectedCallback() {
     super.disconnectedCallback();
-    this._removeThemeAttribute();
+    this._removeThemeClass();
   }
 
   /**
@@ -92,43 +83,22 @@ export class NteThemeSwitcherElement extends LitElement {
   }
 
   /**
-   * Resolve the target DOM element
-   */
-  private _getTargetElement(): HTMLElement | null {
-    switch (this.target) {
-      case 'html':
-        return document.documentElement;
-      case 'body':
-        return document.body;
-      case 'current':
-        return this;
-      default:
-        return document.getElementById(this.target);
-    }
-  }
-
-  /**
-   * Apply the data-theme attribute to the target element
+   * Apply the theme class to the body element
    */
   private _applyTheme() {
-    const el = this._getTargetElement();
-    if (!el) return;
+    this._removeThemeClass();
 
-    if (this._activeTheme === 'default') {
-      el.removeAttribute('data-theme');
-    } else {
-      el.setAttribute('data-theme', this._activeTheme);
+    if (this._activeTheme !== 'default') {
+      document.body.classList.add(`theme-${this._activeTheme}`);
     }
   }
 
   /**
-   * Remove the data-theme attribute from the target element (cleanup)
+   * Remove all theme classes from the body element (cleanup)
    */
-  private _removeThemeAttribute() {
-    const el = this._getTargetElement();
-    if (el) {
-      el.removeAttribute('data-theme');
-    }
+  private _removeThemeClass() {
+    const allThemeClasses = this._themeList.map((t) => `theme-${t}`);
+    document.body.classList.remove(...allThemeClasses);
   }
 
   /**


### PR DESCRIPTION
@paulbuehlerdev 

- Statt dem data-theme Attribute wird nun immer in das body Element per class-attribute die "theme-xy"-Klasse gesetzt.
- Die Target Property wurde in diesem Zuge entfernt
- Die nte-theme-switcher wurde der Demo zu nte-demo-viewer hinzugefügt
- Die nte-theme-switcher Komponenten wurde in die nte-demo-viewer Komponenten gepackt.

Dennoch ist die nte-theme-switcher-Komponenten noch als Einzelkomponenten in nextap-elements vorhanden. Könnte aber bei Bedarf hier gelöscht werden.

